### PR TITLE
to improve flow of smart contract development

### DIFF
--- a/build/components/CompileContracts/index.js
+++ b/build/components/CompileContracts/index.js
@@ -30,7 +30,7 @@ function _handler() {
             _context.prev = 0;
             Spinner.start();
             _context.next = 4;
-            return ExecuteCommand('npm run compile-contracts');
+            return ExecuteCommand('./node_modules/.bin/truffle compile');
 
           case 4:
             result = _context.sent;

--- a/build/components/CompileContracts/index.js
+++ b/build/components/CompileContracts/index.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var Log = require('../../lib/Log');
+
+var ExecuteCommand = require('../../lib/ExecuteCommand');
+
+var Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen compile contracts');
+}
+
+function handler(_x) {
+  return _handler.apply(this, arguments);
+}
+
+function _handler() {
+  _handler = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee(argv) {
+    var result;
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.prev = 0;
+            Spinner.start();
+            _context.next = 4;
+            return ExecuteCommand('npm run compile-contracts');
+
+          case 4:
+            result = _context.sent;
+            console.log(result);
+            Spinner.stop();
+            _context.next = 14;
+            break;
+
+          case 9:
+            _context.prev = 9;
+            _context.t0 = _context["catch"](0);
+            Spinner.stop();
+            Log.ErrorLog('something went wrong!');
+            console.error(_context.t0);
+
+          case 14:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this, [[0, 9]]);
+  }));
+  return _handler.apply(this, arguments);
+}
+
+module.exports = function (yargs) {
+  var command = 'compile contracts';
+  var commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+};

--- a/build/components/DeployContracts/index.js
+++ b/build/components/DeployContracts/index.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var Log = require('../../lib/Log');
+
+var ExecuteCommand = require('../../lib/ExecuteCommand');
+
+var Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen deploy contracts');
+}
+
+function handler(_x) {
+  return _handler.apply(this, arguments);
+}
+
+function _handler() {
+  _handler = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee(argv) {
+    var result;
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.prev = 0;
+            Spinner.start();
+            _context.next = 4;
+            return ExecuteCommand('./node_modules/.bin/truffle deploy --network deployment');
+
+          case 4:
+            result = _context.sent;
+            console.log(result);
+            Spinner.stop();
+            _context.next = 14;
+            break;
+
+          case 9:
+            _context.prev = 9;
+            _context.t0 = _context["catch"](0);
+            Spinner.stop();
+            Log.ErrorLog('something went wrong!');
+            console.error(_context.t0);
+
+          case 14:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this, [[0, 9]]);
+  }));
+  return _handler.apply(this, arguments);
+}
+
+module.exports = function (yargs) {
+  var command = 'deploy contracts';
+  var commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+};

--- a/build/components/TestContracts/index.js
+++ b/build/components/TestContracts/index.js
@@ -30,7 +30,7 @@ function _handler() {
             _context.prev = 0;
             Spinner.start();
             _context.next = 4;
-            return ExecuteCommand('npm run test-contracts');
+            return ExecuteCommand('./node_modules/.bin/ganache-cli & node ./contracts/__test__/index.js');
 
           case 4:
             result = _context.sent;

--- a/build/components/TestContracts/index.js
+++ b/build/components/TestContracts/index.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var Log = require('../../lib/Log');
+
+var ExecuteCommand = require('../../lib/ExecuteCommand');
+
+var Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen test contracts');
+}
+
+function handler(_x) {
+  return _handler.apply(this, arguments);
+}
+
+function _handler() {
+  _handler = _asyncToGenerator(
+  /*#__PURE__*/
+  regeneratorRuntime.mark(function _callee(argv) {
+    var result;
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.prev = 0;
+            Spinner.start();
+            _context.next = 4;
+            return ExecuteCommand('npm run test-contracts');
+
+          case 4:
+            result = _context.sent;
+            console.log(result);
+            Spinner.stop();
+            _context.next = 14;
+            break;
+
+          case 9:
+            _context.prev = 9;
+            _context.t0 = _context["catch"](0);
+            Spinner.stop();
+            Log.ErrorLog('something went wrong!');
+            console.error(_context.t0);
+
+          case 14:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee, this, [[0, 9]]);
+  }));
+  return _handler.apply(this, arguments);
+}
+
+module.exports = function (yargs) {
+  var command = 'test contracts';
+  var commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+};

--- a/build/components/index.js
+++ b/build/components/index.js
@@ -14,4 +14,6 @@ require('./BuildProject')(yargs);
 
 require('./IPFSUpload')(yargs);
 
+require('./TestContracts')(yargs);
+
 module.exports = yargs;

--- a/build/components/index.js
+++ b/build/components/index.js
@@ -18,4 +18,6 @@ require('./TestContracts')(yargs);
 
 require('./CompileContracts')(yargs);
 
+require('./DeployContracts')(yargs);
+
 module.exports = yargs;

--- a/build/components/index.js
+++ b/build/components/index.js
@@ -16,4 +16,6 @@ require('./IPFSUpload')(yargs);
 
 require('./TestContracts')(yargs);
 
+require('./CompileContracts')(yargs);
+
 module.exports = yargs;

--- a/build/lib/ExecuteCommand.js
+++ b/build/lib/ExecuteCommand.js
@@ -4,11 +4,11 @@ var cmd = require('node-cmd');
 
 module.exports = function (command) {
   return new Promise(function (resolve, reject) {
-    cmd.get(command, function (error) {
+    cmd.get(command, function (error, data) {
       if (error) {
         reject(error);
       } else {
-        resolve(true);
+        resolve(data);
       }
     });
   });

--- a/src/components/CompileContracts/index.js
+++ b/src/components/CompileContracts/index.js
@@ -9,7 +9,7 @@ function builder(yargs) {
 async function handler(argv) {
   try {
     Spinner.start();
-    const result = await ExecuteCommand('npm run compile-contracts');
+    const result = await ExecuteCommand('./node_modules/.bin/truffle compile');
     console.log(result);
     Spinner.stop();
   } catch (error) {

--- a/src/components/CompileContracts/index.js
+++ b/src/components/CompileContracts/index.js
@@ -1,0 +1,26 @@
+const Log = require('../../lib/Log');
+const ExecuteCommand = require('../../lib/ExecuteCommand');
+const Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen compile contracts');
+}
+
+async function handler(argv) {
+  try {
+    Spinner.start();
+    const result = await ExecuteCommand('npm run compile-contracts');
+    console.log(result);
+    Spinner.stop();
+  } catch (error) {
+    Spinner.stop();
+    Log.ErrorLog('something went wrong!');
+    console.error(error);
+  }
+}
+
+module.exports = function (yargs) {
+  const command = 'compile contracts';
+  const commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+}

--- a/src/components/DeployContracts/index.js
+++ b/src/components/DeployContracts/index.js
@@ -1,0 +1,26 @@
+const Log = require('../../lib/Log');
+const ExecuteCommand = require('../../lib/ExecuteCommand');
+const Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen deploy contracts');
+}
+
+async function handler(argv) {
+  try {
+    Spinner.start();
+    const result = await ExecuteCommand('./node_modules/.bin/truffle deploy --network deployment');
+    console.log(result);
+    Spinner.stop();
+  } catch (error) {
+    Spinner.stop();
+    Log.ErrorLog('something went wrong!');
+    console.error(error);
+  }
+}
+
+module.exports = function (yargs) {
+  const command = 'deploy contracts';
+  const commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+}

--- a/src/components/TestContracts/index.js
+++ b/src/components/TestContracts/index.js
@@ -1,0 +1,26 @@
+const Log = require('../../lib/Log');
+const ExecuteCommand = require('../../lib/ExecuteCommand');
+const Spinner = require('../../lib/Spinner');
+
+function builder(yargs) {
+  return yargs.example('kaizen test contracts');
+}
+
+async function handler(argv) {
+  try {
+    Spinner.start();
+    const result = await ExecuteCommand('npm run test-contracts');
+    console.log(result);
+    Spinner.stop();
+  } catch (error) {
+    Spinner.stop();
+    Log.ErrorLog('something went wrong!');
+    console.error(error);
+  }
+}
+
+module.exports = function (yargs) {
+  const command = 'test contracts';
+  const commandDescription = 'To execute truffle testing scripts';
+  yargs.command(command, commandDescription, builder, handler);
+}

--- a/src/components/TestContracts/index.js
+++ b/src/components/TestContracts/index.js
@@ -9,7 +9,7 @@ function builder(yargs) {
 async function handler(argv) {
   try {
     Spinner.start();
-    const result = await ExecuteCommand('npm run test-contracts');
+    const result = await ExecuteCommand('./node_modules/.bin/ganache-cli & node ./contracts/__test__/index.js');
     console.log(result);
     Spinner.stop();
   } catch (error) {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,5 +7,6 @@ require('./CreateProject')(yargs);
 require('./BuildProject')(yargs);
 require('./IPFSUpload')(yargs);
 require('./TestContracts')(yargs);
+require('./CompileContracts')(yargs);
 
 module.exports = yargs;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,5 +6,6 @@ require('./RemovePlugin')(yargs);
 require('./CreateProject')(yargs);
 require('./BuildProject')(yargs);
 require('./IPFSUpload')(yargs);
+require('./TestContracts')(yargs);
 
 module.exports = yargs;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,5 +8,6 @@ require('./BuildProject')(yargs);
 require('./IPFSUpload')(yargs);
 require('./TestContracts')(yargs);
 require('./CompileContracts')(yargs);
+require('./DeployContracts')(yargs);
 
 module.exports = yargs;

--- a/src/lib/ExecuteCommand.js
+++ b/src/lib/ExecuteCommand.js
@@ -2,11 +2,11 @@ const cmd = require('node-cmd');
 
 module.exports = function(command) {
   return new Promise(function(resolve, reject) {
-    cmd.get(command, function (error) {
+    cmd.get(command, function (error, data) {
       if(error) {
         reject(error);
       } else {
-        resolve(true);
+        resolve(data);
       }
     });
   });


### PR DESCRIPTION
To provide a better way for users to develop their smart contract via KAIZEN

### Unit test the smart contracts
#### command
`$ kaizen test contracts`

#### usage
Developer can write unit tests and put them all together inside the `contracts/__test__`.
Once you execute `kaizen test contracts`, kaizen will run automatically each unit test file for you.

* * *

### Compile the smart contracts
#### command
`$ kaizen compile contracts`

#### usage
Your smart contracts should be placed in `contracts/`. Once you execute command `kaizen compile contracts` , all of the contracts will be compiled and the ABI files will output to the `build/smart_contracts` by default. The output path is specified in __kaizen.json__, you can modify them at will.
```
"ethereum": {
  "build_output_path": "./build/smart_contracts",
}
```

* * *

### Deploy the smart contracts
#### command 
`$ kaizen deploy contracts`

#### usage
To deploy contracts, you can simply execute `kaizen deploy contracts`. All you have to do is setting the configuration of deployment in __kaizen.json__.
```
"ethereum": {
  "provider": "https://ropsten.infura.io/<Your Infura API Key>",
  "network_id": 3,
  "mnemonic": "",
  "develop_port": 8545
}
```